### PR TITLE
Fix fresh deployment boot failure and isolate tests from game server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,8 @@ APP_NAME="PZ Server Manager"
 APP_ENV=production
 APP_KEY=
 APP_DEBUG=false
-APP_URL=http://localhost:8000
-APP_PORT=8000
+APP_URL=http://localhost:8080
+APP_PORT=8080
 
 DB_CONNECTION=pgsql
 DB_HOST=db

--- a/.env.production.example
+++ b/.env.production.example
@@ -35,7 +35,7 @@ APP_ENV=production
 APP_KEY=
 APP_DEBUG=false
 APP_URL=http://localhost
-APP_PORT=8000
+APP_PORT=80
 
 # ── Database ────────────────────────────────────────────────────────────────
 DB_CONNECTION=pgsql

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -2,6 +2,7 @@ vendor/
 node_modules/
 .env
 .env.backup
+bootstrap/cache/*.php
 storage/logs/*
 storage/framework/cache/data/*
 storage/framework/sessions/*

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -51,8 +51,11 @@ RUN npm ci
 # Copy application code
 COPY . .
 
-# Generate autoload BEFORE npm build (Wayfinder plugin needs artisan)
-RUN composer dump-autoload --optimize --no-dev
+# Generate autoload & discover packages (purges dev-only providers from cache)
+RUN composer dump-autoload --optimize --no-dev \
+    && APP_KEY=base64:dGVtcG9yYXJ5LWJ1aWxkLWtleS1mb3ItZG9ja2VyMTIzNA== \
+       DB_CONNECTION=sqlite DB_DATABASE=":memory:" \
+       php artisan package:discover --ansi
 
 # Build frontend assets
 # Wayfinder plugin runs `php artisan wayfinder:generate` which needs APP_KEY

--- a/app/docker/entrypoint.sh
+++ b/app/docker/entrypoint.sh
@@ -64,6 +64,11 @@ if [ -z "$APP_KEY" ] || [ "$APP_KEY" = "base64:" ]; then
     echo "[entrypoint] Add this to your .env to persist across restarts."
 fi
 
+# ── Package discovery ──────────────────────────────────────────────
+# Host bind-mount may contain stale bootstrap/cache from dev deps — purge and regenerate
+rm -f /var/www/html/bootstrap/cache/packages.php /var/www/html/bootstrap/cache/services.php
+php artisan package:discover --no-interaction 2>/dev/null || true
+
 # ── Only run setup tasks for the main app (not queue worker) ─────────
 if echo "$@" | grep -q "supervisord"; then
 

--- a/app/tests/Feature/Admin/AutoRestartTest.php
+++ b/app/tests/Feature/Admin/AutoRestartTest.php
@@ -192,11 +192,14 @@ describe('Scheduled restart times', function () {
     });
 
     it('enforces max 5 scheduled times', function () {
-        ScheduledRestartTime::factory()->count(5)->create();
+        // Use explicit times to avoid unique-constraint collision with the 6th attempt
+        foreach (['01:00', '05:00', '09:00', '13:00', '17:00'] as $time) {
+            ScheduledRestartTime::factory()->create(['time' => $time]);
+        }
 
         $this->actingAs($this->admin)
             ->postJson(route('admin.auto-restart.times.store'), [
-                'time' => '23:00',
+                'time' => '23:30',
             ])
             ->assertStatus(422)
             ->assertJson(['message' => 'Maximum of 5 scheduled times allowed']);

--- a/app/tests/Feature/Auth/PzAccountLoginTest.php
+++ b/app/tests/Feature/Auth/PzAccountLoginTest.php
@@ -11,6 +11,14 @@ uses(RefreshDatabase::class);
 
 beforeEach(function () {
     $this->withoutVite();
+    // Always use a temp PZ SQLite DB — never hit the real game server
+    $this->pzDbPath = setupPzSqliteForLogin();
+});
+
+afterEach(function () {
+    if (isset($this->pzDbPath)) {
+        cleanupPzSqlite($this->pzDbPath);
+    }
 });
 
 /**
@@ -101,7 +109,6 @@ describe('Existing web user login', function () {
 
 describe('Game-first player instant login', function () {
     it('auto-creates web account from PZ SQLite with PZ-hashed password', function () {
-        $dbPath = setupPzSqliteForLogin();
         insertPzLoginAccount('game_player', 'mypass');
 
         $this->post(route('login.store'), [
@@ -124,7 +131,7 @@ describe('Game-first player instant login', function () {
         expect($entry->user_id)->toBe($user->id);
         expect($entry->active)->toBeTrue();
 
-        cleanupPzSqlite($dbPath);
+
     });
 
     it('auto-creates web account from PZ SQLite with plain text password', function () {
@@ -143,11 +150,10 @@ describe('Game-first player instant login', function () {
         expect($user)->not->toBeNull();
         expect(Hash::check('plainpass', $user->password))->toBeTrue();
 
-        cleanupPzSqlite($dbPath);
+
     });
 
     it('rejects wrong password and does not create account', function () {
-        $dbPath = setupPzSqliteForLogin();
         insertPzLoginAccount('pz_user', 'correctpass');
 
         $this->post(route('login.store'), [
@@ -158,12 +164,10 @@ describe('Game-first player instant login', function () {
         $this->assertGuest();
         expect(User::where('username', 'pz_user')->exists())->toBeFalse();
 
-        cleanupPzSqlite($dbPath);
+
     });
 
     it('rejects login for username not in PZ SQLite', function () {
-        $dbPath = setupPzSqliteForLogin();
-
         $this->post(route('login.store'), [
             'username' => 'nonexistent',
             'password' => 'anypass',
@@ -171,7 +175,7 @@ describe('Game-first player instant login', function () {
 
         $this->assertGuest();
 
-        cleanupPzSqlite($dbPath);
+
     });
 });
 
@@ -206,7 +210,7 @@ describe('Sync-created user login', function () {
         $user->refresh();
         expect(Hash::check('gamepass', $user->password))->toBeTrue();
 
-        cleanupPzSqlite($dbPath);
+
     });
 });
 
@@ -223,12 +227,15 @@ describe('PZ SQLite unavailable', function () {
         // Should not crash — just a normal login failure
         $response->assertStatus(302);
         $this->assertGuest();
+
+        // Restore temp DB so afterEach cleanup works
+        config(['database.connections.pz_sqlite.database' => $this->pzDbPath]);
+        DB::purge('pz_sqlite');
     });
 });
 
 describe('Sync command fixes networkPlayers race condition', function () {
     it('creates missing WhitelistEntry and fixes password for user created from networkPlayers', function () {
-        $dbPath = setupPzSqliteForLogin();
 
         // Simulate Pass 2 having created a user with a random password (no WhitelistEntry)
         $user = User::forceCreate([
@@ -250,11 +257,10 @@ describe('Sync command fixes networkPlayers race condition', function () {
         expect($entry->user_id)->toBe($user->id);
         expect($entry->active)->toBeTrue();
 
-        cleanupPzSqlite($dbPath);
+
     });
 
     it('does not duplicate WhitelistEntry if one already exists', function () {
-        $dbPath = setupPzSqliteForLogin();
 
         $user = User::factory()->create(['username' => 'linked_player']);
         WhitelistEntry::create([
@@ -272,6 +278,6 @@ describe('Sync command fixes networkPlayers race condition', function () {
 
         expect(WhitelistEntry::where('pz_username', 'linked_player')->count())->toBe(1);
 
-        cleanupPzSqlite($dbPath);
+
     });
 });

--- a/app/tests/Feature/Auth/RegistrationTest.php
+++ b/app/tests/Feature/Auth/RegistrationTest.php
@@ -4,11 +4,44 @@ namespace Tests\Feature\Auth;
 
 use App\Models\WhitelistEntry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class RegistrationTest extends TestCase
 {
     use RefreshDatabase;
+
+    private string $pzDbPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Always use a temp PZ SQLite DB — never hit the real game server
+        $this->pzDbPath = sys_get_temp_dir().'/pz_test_reg_'.uniqid().'.db';
+        touch($this->pzDbPath);
+
+        config(['database.connections.pz_sqlite.database' => $this->pzDbPath]);
+        DB::purge('pz_sqlite');
+
+        DB::connection('pz_sqlite')->statement('
+            CREATE TABLE IF NOT EXISTS whitelist (
+                username TEXT PRIMARY KEY,
+                password TEXT,
+                world TEXT DEFAULT NULL,
+                role INTEGER DEFAULT 2,
+                authType INTEGER DEFAULT 1
+            )
+        ');
+    }
+
+    protected function tearDown(): void
+    {
+        DB::connection('pz_sqlite')->disconnect();
+        @unlink($this->pzDbPath);
+
+        parent::tearDown();
+    }
 
     public function test_registration_screen_can_be_rendered()
     {

--- a/app/tests/Feature/PlayerRegistrationTest.php
+++ b/app/tests/Feature/PlayerRegistrationTest.php
@@ -12,6 +12,15 @@ uses(RefreshDatabase::class);
 
 beforeEach(function () {
     $this->withoutVite();
+    // Always use a temp PZ SQLite DB — never hit the real game server
+    $this->pzDbPath = setupTestPzSqlite();
+});
+
+afterEach(function () {
+    if (isset($this->pzDbPath)) {
+        DB::connection('pz_sqlite')->disconnect();
+        @unlink($this->pzDbPath);
+    }
 });
 
 /**
@@ -280,10 +289,13 @@ describe('PZ account sync command', function () {
 
         $this->artisan('pz:sync-accounts')
             ->assertFailed();
+
+        // Restore the temp DB so afterEach cleanup works
+        config(['database.connections.pz_sqlite.database' => $this->pzDbPath]);
+        DB::purge('pz_sqlite');
     });
 
     it('auto-creates web user from PZ account', function () {
-        $dbPath = setupTestPzSqlite();
         insertPzAccount('ingame_player', 'gamepass123');
 
         $this->artisan('pz:sync-accounts')
@@ -294,13 +306,9 @@ describe('PZ account sync command', function () {
         expect($user->role)->toBe(UserRole::Player);
         expect($user->email)->toBeNull();
         expect(Hash::check('gamepass123', $user->password))->toBeTrue();
-
-        DB::connection('pz_sqlite')->disconnect();
-        @unlink($dbPath);
     });
 
     it('links whitelist entry to auto-created user', function () {
-        $dbPath = setupTestPzSqlite();
         insertPzAccount('linked_player', 'pass123');
 
         $this->artisan('pz:sync-accounts')
@@ -314,13 +322,9 @@ describe('PZ account sync command', function () {
         expect($entry->pz_password_hash)->toBe('pass123');
         expect($entry->active)->toBeTrue();
         expect($entry->synced_at)->not->toBeNull();
-
-        DB::connection('pz_sqlite')->disconnect();
-        @unlink($dbPath);
     });
 
     it('links existing whitelist entry when auto-creating user', function () {
-        $dbPath = setupTestPzSqlite();
         insertPzAccount('existing_entry', 'pass456');
 
         // Pre-existing WhitelistEntry without a user_id
@@ -339,13 +343,9 @@ describe('PZ account sync command', function () {
         $entry->refresh();
         expect($entry->user_id)->toBe($user->id);
         expect($entry->pz_password_hash)->toBe('pass456');
-
-        DB::connection('pz_sqlite')->disconnect();
-        @unlink($dbPath);
     });
 
     it('skips usernames that already exist in users table', function () {
-        $dbPath = setupTestPzSqlite();
         User::factory()->create(['username' => 'taken_user']);
         insertPzAccount('taken_user', 'gamepass');
 
@@ -354,14 +354,9 @@ describe('PZ account sync command', function () {
 
         // Should still be only one user with this username
         expect(User::where('username', 'taken_user')->count())->toBe(1);
-
-        DB::connection('pz_sqlite')->disconnect();
-        @unlink($dbPath);
     });
 
     it('detects password change from PZ and syncs to web', function () {
-        $dbPath = setupTestPzSqlite();
-
         // User already exists with linked whitelist entry
         $user = User::factory()->create([
             'username' => 'sync_player',
@@ -386,14 +381,9 @@ describe('PZ account sync command', function () {
 
         $entry = WhitelistEntry::where('pz_username', 'sync_player')->first();
         expect($entry->pz_password_hash)->toBe('newgamepass');
-
-        DB::connection('pz_sqlite')->disconnect();
-        @unlink($dbPath);
     });
 
     it('does not update password when unchanged', function () {
-        $dbPath = setupTestPzSqlite();
-
         $user = User::factory()->create([
             'username' => 'stable_player',
             'password' => Hash::make('samepass'),
@@ -415,13 +405,9 @@ describe('PZ account sync command', function () {
         $entry = WhitelistEntry::where('pz_username', 'stable_player')->first();
         // synced_at should NOT have changed since password is the same
         expect($entry->synced_at->toDateTimeString())->toBe($syncedAt->toDateTimeString());
-
-        DB::connection('pz_sqlite')->disconnect();
-        @unlink($dbPath);
     });
 
     it('handles multiple PZ accounts in one sync run', function () {
-        $dbPath = setupTestPzSqlite();
         insertPzAccount('player_one', 'pass1');
         insertPzAccount('player_two', 'pass2');
         insertPzAccount('player_three', 'pass3');
@@ -431,9 +417,6 @@ describe('PZ account sync command', function () {
             ->expectsOutputToContain('3 created');
 
         expect(User::whereIn('username', ['player_one', 'player_two', 'player_three'])->count())->toBe(3);
-
-        DB::connection('pz_sqlite')->disconnect();
-        @unlink($dbPath);
     });
 });
 
@@ -473,7 +456,6 @@ describe('Access without email verification', function () {
 
 describe('Password sync to PZ SQLite', function () {
     it('syncs web password change to PZ SQLite', function () {
-        $dbPath = setupTestPzSqlite();
         insertPzAccount('pw_sync_user', 'original');
 
         $user = User::factory()->create(['username' => 'pw_sync_user']);
@@ -507,9 +489,6 @@ describe('Password sync to PZ SQLite', function () {
         // Verify WhitelistEntry tracking updated
         $entry = WhitelistEntry::where('pz_username', 'pw_sync_user')->first();
         expect(password_verify(md5('newsecret'), $entry->pz_password_hash))->toBeTrue();
-
-        DB::connection('pz_sqlite')->disconnect();
-        @unlink($dbPath);
     });
 
     it('updates PostgreSQL even when PZ SQLite is unavailable', function () {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -146,8 +146,17 @@ prompt PZ_SERVER_PASSWORD "Server password (empty = open)" ""
 
 # ── Web Panel ─────────────────────────────────────────────────────────────────
 section "Web Panel"
-prompt APP_PORT "Port" "8000"
-DEFAULT_URL="http://localhost:${APP_PORT}"
+if [ "$APP_ENV" = "production" ]; then
+    DEFAULT_PORT="80"
+else
+    DEFAULT_PORT="8080"
+fi
+prompt APP_PORT "Port" "$DEFAULT_PORT"
+if [ "$APP_PORT" = "80" ]; then
+    DEFAULT_URL="http://localhost"
+else
+    DEFAULT_URL="http://localhost:${APP_PORT}"
+fi
 prompt APP_URL "URL" "$DEFAULT_URL"
 
 # ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
- Fix BoostServiceProvider crash: host bind-mount overwrites bootstrap/cache with dev-only provider cache. Entrypoint now purges stale cache files and runs package:discover before any artisan command.
- Add package:discover to Dockerfile build and bootstrap/cache to .dockerignore for defense-in-depth.
- Default web panel port to 80 (production) / 8080 (development) instead of
  8000. Setup wizard picks the right default based on environment choice.
- Isolate all PZ SQLite tests: registration, login, and sync tests now use temp databases in beforeEach/setUp — never touch the real game server DB.
- Fix flaky AutoRestartTest: use explicit times to avoid unique-constraint collision from random factory data.

643 tests passing (2600 assertions), 0 failures.